### PR TITLE
Allow multiline code in the REPL

### DIFF
--- a/docs/interpreters/latest/index.html
+++ b/docs/interpreters/latest/index.html
@@ -1,4 +1,5 @@
 <!doctype html>
+
 <head>
 	<meta charset="utf-8">
 	<title>TinyAPL Interpreter</title>
@@ -30,7 +31,7 @@
 			margin-bottom: 5px;
 			z-index: 100000000000;
 		}
-	
+
 		#buttons button {
 			font-family: var(--font-mono);
 		}
@@ -39,23 +40,23 @@
 			width: auto;
 			max-width: 100%;
 		}
-	
+
 		#output {
 			height: 90%;
 			font-family: var(--font-mono);
 		}
-		
+
 		#output * {
 			text-wrap: wrap;
 			overflow-wrap: break-word;
 		}
-		
-		#input, #highlighted {
+
+		#input,
+		#highlighted {
 			width: 97.5%;
 			font-family: var(--font-mono);
 			margin: 2.5px;
 			padding: 2.5px;
-			height: 1.25em;
 			grid-row: 1;
 			grid-column: 1;
 			overflow-x: auto;
@@ -76,12 +77,12 @@
 		#highlighted {
 			z-index: 0;
 		}
-		
+
 		#button {
 			width: auto;
 			font-family: var(--font-mono);
 		}
-		
+
 		#input-wrapper {
 			display: inline-grid;
 			width: 90%;
@@ -101,37 +102,29 @@
 			display: inline-block;
 			margin: 0;
 		}
-		
+
 		.char {
 			display: inline-block;
 			min-width: 1ch;
 		}
-		
+
 		.code {
 			color: grey;
 		}
-		
+
 		.error {
 			background: #ffcccc;
 			color: red;
 		}
-		
+
 		.result {
 			color: black;
 		}
-		
+
 		.quad {
 			color: dimgrey;
 		}
 
-		.pad {
-			display: inline-flex;
-			width: 6ch;
-			height: 1ch;
-			justify-content: end;
-			padding-inline-end: 1ch;
-		}
-		
 		.image {
 			border: 1px solid black;
 			display: block;
@@ -146,11 +139,16 @@
 			vertical-align: top;
 		}
 
-		table.vector, table.vector > tbody > tr, table.vector > tbody > tr > td, table.matrix, table.matrix > tbody > tr, table.matrix > tbody > tr > td {
+		table.vector,
+		table.vector>tbody>tr,
+		table.vector>tbody>tr>td,
+		table.matrix,
+		table.matrix>tbody>tr,
+		table.matrix>tbody>tr>td {
 			border: 2px solid black;
 			border-collapse: collapse;
 		}
-		
+
 		.struct ul {
 			margin-block: 0;
 		}
@@ -164,19 +162,35 @@
 			display: inline-block;
 			box-sizing: border-box;
 			animation: loader-rotation 1s linear infinite;
-    }
+
+			position: absolute;
+			left: 4ch;
+			top: 0.5ch;
+		}
+
+		.executed {
+			padding-left: 6ch;
+			position: relative;
+		}
 
 		@keyframes loader-rotation {
 			0% {
 				transform: rotate(0deg);
 			}
+
 			100% {
 				transform: rotate(360deg);
 			}
-    } 
-@keyframes l3 {to{transform: rotate(1turn)}}
+		}
+
+		@keyframes l3 {
+			to {
+				transform: rotate(1turn)
+			}
+		}
 	</style>
 </head>
+
 <body>
 	<h1 id="loading">Loading...</h1>
 	<input id="fancyarrays" type="checkbox" checked>
@@ -187,10 +201,13 @@
 		<h1>Info</h1>
 		<h2>Inputting Glyphs</h2>
 		<p>
-			To input glyphs, you can either use the language bar, or the prefix key, which is <kbd id="prefixkey"></kbd>.
+			To input glyphs, you can either use the language bar, or the prefix key, which is <kbd
+				id="prefixkey"></kbd>.
 			The keyboard layout is shown in the image below.
-			To input a glyph in the middle column, press the prefix key once and then the corresponding key (shown in the first column), holding <kbd>Shift</kbd> if it's in the upper row.
-			To input a glyph in the last column, press the prefix key twice and then the corresponding key, shifing as before.
+			To input a glyph in the middle column, press the prefix key once and then the corresponding key (shown in
+			the first column), holding <kbd>Shift</kbd> if it's in the upper row.
+			To input a glyph in the last column, press the prefix key twice and then the corresponding key, shifing as
+			before.
 			Note that many (probably most) available glyphs currently correspond to no behavior and will error when ran.
 		</p>
 		<h2>Controls</h2>
@@ -198,93 +215,202 @@
 			To run your code, you can press <kbd>Enter</kbd> or the Run button.
 			To edit code you already ran, click on it.
 			Similarly, you can click on an output to put it into the input bar.
-			You can also scroll through previously ran code with <kbd>Shift</kbd>+<kbd>↑</kbd> and <kbd>Shift</kbd>+<kbd>↓</kbd>
+			You can also scroll through previously ran code with <kbd>Shift</kbd>+<kbd>↑</kbd> and
+			<kbd>Shift</kbd>+<kbd>↓</kbd>
 		</p>
 		<h2>Quads</h2>
 		<p>
 			In addition to all the quad names available normally in TinyAPL, there are additional ones:
 		</p>
 		<ul>
-			<li><div>
-				<pre class="hl">⎕Debug</pre>: acts exactly like <pre class="hl">⊢</pre>,
-				except the input(s) are printed to the JavaScript console.
-				Useful if you want to create your own quads and want to look at the JS structure of arrays.
-			</div></li>
-			<li><div>
-				<pre class="hl">id←⎕CreateImage size</pre>: adds a blank image of size <pre class="hl">size</pre>,
-				which can either be a scalar number (creating a square image) or a vector of <pre class="hl">⟨height⋄width⟩</pre>.
-				Returns an <pre class="hl">id</pre> (which is currently a number, but it's an implementation detail)
-				which can be used to update the image display.
-			</div></li>
-			<li><div>
-				<pre class="hl">[id] ⎕DisplayImage data</pre>: renders an image, either to a new display or to the one indicated by <pre class="hl">id</pre>.
-				<pre class="hl">data</pre> should be a real array of rank <pre class="hl">2</pre> or <pre class="hl">3</pre>
-				(if it's of rank <pre class="hl">2</pre> a trailing unit axis is introduced as in <pre class="hl">∧⍤0 data</pre>)
-				and the last axis must be of length <pre class="hl">1</pre>, <pre class="hl">2</pre>, <pre class="hl">3</pre>, <pre class="hl">4</pre>.
-				If the last axis has length <pre class="hl">1</pre>, <pre class="hl">data</pre> is interpreted as grayscale;
-				if it has length <pre class="hl">2</pre>, it is interpreted as grayscale + alpha,
-				if it has length <pre class="hl">3</pre>, it is interpreted as RGB,
-				if it has length <pre class="hl">4</pre>, it is interpreted as RGBA.
-				In all cases, <pre class="hl">0</pre> is the lowest value of the channel and <pre class="hl">1</pre> is the highest value in the channel.
-				All data outside this range is clamped.
-			</div></li>
-			<div><li>
-				<pre class="hl">[delay] ⎕PlayAnimation data</pre>: plays an animation.
-				<pre class="hl">data</pre> should be a real array of rank <pre class="hl">3</pre> or <pre class="hl">4</pre>.
-				Each major cell of <pre class="hl">data</pre> is used as a frame for the animation, in the way described for <pre class="hl">⎕DisplayImage</pre>.
-				<pre class="hl">delay</pre> is the delay between frames in seconds and defaults to <pre class="hl">0.1</pre>.
-			</li></div>
-			<li><div>
-				<pre class="hl">[mode] ⎕ScatterPlot data</pre>: renders a plot.
-				<pre class="hl">data</pre> should be a real array of rank <pre class="hl">2</pre> or <pre class="hl">3</pre>
-				(if it's of rank <pre class="hl">2</pre> a leading unit axis is introduce as in <pre class="hl">∧data</pre>)
-				and the last axis must be of length <pre class="hl">2</pre>.
-				Matrices of <pre class="hl">data</pre> are interpreted as scatter plot datasets, with each vector of the matrix being a <pre class="hl">⟨x⋄y⟩</pre> pair.
-				If <pre class="hl">mode</pre> is provided, it must be one of <pre class="hl">"markers"</pre>, which is the default and displays dots;
-				<pre class="hl">"lines"</pre>, which connects the provided points (and attempts to do so smoothly);
-				<pre class="hl">"lines+markers"</pre>, which displays both.
-			</div></li>
-			<li><div>
-				<pre class="hl">[start] fns ⎕_Graph end</pre>: graphs functions.
-				<pre class="hl">fns</pre> should be a function, a vector of functions, or a vector of pairs of functions and labels.
-				The default labels are the representations of the functions.
-				<pre class="hl">start</pre> and <pre class="hl">end</pre> are the start and end of the graph, respectively. The default <pre class="hl">start</pre> is <pre class="hl">0</pre>.
-				The function is evaluated at <pre class="hl">501</pre> points evenly spaced between <pre class="hl">start</pre> and <pre class="hl">end</pre>.
-			</div></li>
-			<li><div>
-				<pre class="hl">[sampleRate] ⎕PlayAudio data</pre>: plays audio.
-				<pre class="hl">data</pre> should be a real array of rank <pre class="hl">1</pre> or <pre class="hl">2</pre>
-				(if it's of rank <pre class="hl">1</pre> a leading unit axis is introduced as in <pre class="hl">∧data</pre>).
-				Vectors of <pre class="hl">data</pre> are channels containing samples.
-				<pre class="hl">sampleRate</pre> is the sample rate of <pre class="hl">data</pre> and defaults to <pre class="hl">44100</pre>.
-			</div></li>
-			<li><div>
-				<pre class="hl">data←[type] ⎕Fetch url</pre>: fetches data from the web.
-				<pre class="hl">url</pre> must be a string.
-				If <pre class="hl">type</pre> is not provided, <pre class="hl">url</pre> is fetched and <pre class="hl">data</pre> is the text content of the result.
-				If <pre class="hl">type</pre> is provided, <pre class="hl">url</pre> is fetched as binary and it is interpreted according to <pre class="hl">type</pre>:
-				<ul>
-					<li><pre class="hl">1</pre>: bits</li>
-					<li><pre class="hl">8</pre>: unsigned 8-bit</li>
-					<li><pre class="hl">¯8</pre>: signed 8-bit</li>
-					<li><pre class="hl">16</pre>: unsigned 16-bit little endian</li>
-					<li><pre class="hl">¯16</pre>: signed 16-bit little endian</li>
-					<li><pre class="hl">0ᴊ16</pre>: unsigned 16-bit big endian</li>
-					<li><pre class="hl">0ᴊ¯16</pre>: signed 16-bit big endian</li>
-					<li><pre class="hl">32</pre>: unsigned 32-bit little endian</li>
-					<li><pre class="hl">¯32</pre>: signed 32-bit little endian</li>
-					<li><pre class="hl">0ᴊ32</pre>: unsigned 32-bit big endian</li>
-					<li><pre class="hl">0ᴊ¯32</pre>: signed 32-bit big-endian</li>
-					<li><pre class="hl">0.32</pre>: 32-bit float little endian</li>
-					<li><pre class="hl">0ᴊ0.32</pre>: 32-bit float big endian</li>
-					<li><pre class="hl">0.64</pre>: 64-bit float little endian</li>
-					<li><pre class="hl">0ᴊ0.64</pre>: 64-bit float big endian</li>
-				</ul>
-				64-bit integers are not provided as they cannot be losslessly loaded into float64s, TinyAPL's native real number type.
-			</div></li>
-			<li><div>
-				<pre class="hl">⎕last</pre>, <pre class="hl">⎕Last</pre>, <pre class="hl">⎕_Last</pre>, <pre class="hl">⎕_Last_</pre>: access the result of the last successful code ran.
-			</div></li>
+			<li>
+				<div>
+					<pre class="hl">⎕Debug</pre>: acts exactly like
+					<pre class="hl">⊢</pre>,
+					except the input(s) are printed to the JavaScript console.
+					Useful if you want to create your own quads and want to look at the JS structure of arrays.
+				</div>
+			</li>
+			<li>
+				<div>
+					<pre class="hl">id←⎕CreateImage size</pre>: adds a blank image of size
+					<pre class="hl">size</pre>,
+					which can either be a scalar number (creating a square image) or a vector of
+					<pre class="hl">⟨height⋄width⟩</pre>.
+					Returns an
+					<pre class="hl">id</pre> (which is currently a number, but it's an implementation detail)
+					which can be used to update the image display.
+				</div>
+			</li>
+			<li>
+				<div>
+					<pre class="hl">[id] ⎕DisplayImage data</pre>: renders an image, either to a new display or to the
+					one indicated by
+					<pre class="hl">id</pre>.
+					<pre class="hl">data</pre> should be a real array of rank
+					<pre class="hl">2</pre> or
+					<pre class="hl">3</pre>
+					(if it's of rank
+					<pre class="hl">2</pre> a trailing unit axis is introduced as in
+					<pre class="hl">∧⍤0 data</pre>)
+					and the last axis must be of length
+					<pre class="hl">1</pre>,
+					<pre class="hl">2</pre>,
+					<pre class="hl">3</pre>,
+					<pre class="hl">4</pre>.
+					If the last axis has length
+					<pre class="hl">1</pre>,
+					<pre class="hl">data</pre> is interpreted as grayscale;
+					if it has length
+					<pre class="hl">2</pre>, it is interpreted as grayscale + alpha,
+					if it has length
+					<pre class="hl">3</pre>, it is interpreted as RGB,
+					if it has length
+					<pre class="hl">4</pre>, it is interpreted as RGBA.
+					In all cases,
+					<pre class="hl">0</pre> is the lowest value of the channel and
+					<pre class="hl">1</pre> is the highest value in the channel.
+					All data outside this range is clamped.
+				</div>
+			</li>
+			<div>
+				<li>
+					<pre class="hl">[delay] ⎕PlayAnimation data</pre>: plays an animation.
+					<pre class="hl">data</pre> should be a real array of rank
+					<pre class="hl">3</pre> or
+					<pre class="hl">4</pre>.
+					Each major cell of
+					<pre class="hl">data</pre> is used as a frame for the animation, in the way described for
+					<pre class="hl">⎕DisplayImage</pre>.
+					<pre class="hl">delay</pre> is the delay between frames in seconds and defaults to
+					<pre class="hl">0.1</pre>.
+				</li>
+			</div>
+			<li>
+				<div>
+					<pre class="hl">[mode] ⎕ScatterPlot data</pre>: renders a plot.
+					<pre class="hl">data</pre> should be a real array of rank
+					<pre class="hl">2</pre> or
+					<pre class="hl">3</pre>
+					(if it's of rank
+					<pre class="hl">2</pre> a leading unit axis is introduce as in
+					<pre class="hl">∧data</pre>)
+					and the last axis must be of length
+					<pre class="hl">2</pre>.
+					Matrices of
+					<pre class="hl">data</pre> are interpreted as scatter plot datasets, with each vector of the matrix
+					being a
+					<pre class="hl">⟨x⋄y⟩</pre> pair.
+					If
+					<pre class="hl">mode</pre> is provided, it must be one of
+					<pre class="hl">"markers"</pre>, which is the default and displays dots;
+					<pre class="hl">"lines"</pre>, which connects the provided points (and attempts to do so smoothly);
+					<pre class="hl">"lines+markers"</pre>, which displays both.
+				</div>
+			</li>
+			<li>
+				<div>
+					<pre class="hl">[start] fns ⎕_Graph end</pre>: graphs functions.
+					<pre class="hl">fns</pre> should be a function, a vector of functions, or a vector of pairs of
+					functions and labels.
+					The default labels are the representations of the functions.
+					<pre class="hl">start</pre> and
+					<pre class="hl">end</pre> are the start and end of the graph, respectively. The default
+					<pre class="hl">start</pre> is
+					<pre class="hl">0</pre>.
+					The function is evaluated at
+					<pre class="hl">501</pre> points evenly spaced between
+					<pre class="hl">start</pre> and
+					<pre class="hl">end</pre>.
+				</div>
+			</li>
+			<li>
+				<div>
+					<pre class="hl">[sampleRate] ⎕PlayAudio data</pre>: plays audio.
+					<pre class="hl">data</pre> should be a real array of rank
+					<pre class="hl">1</pre> or
+					<pre class="hl">2</pre>
+					(if it's of rank
+					<pre class="hl">1</pre> a leading unit axis is introduced as in
+					<pre class="hl">∧data</pre>).
+					Vectors of
+					<pre class="hl">data</pre> are channels containing samples.
+					<pre class="hl">sampleRate</pre> is the sample rate of
+					<pre class="hl">data</pre> and defaults to
+					<pre class="hl">44100</pre>.
+				</div>
+			</li>
+			<li>
+				<div>
+					<pre class="hl">data←[type] ⎕Fetch url</pre>: fetches data from the web.
+					<pre class="hl">url</pre> must be a string.
+					If
+					<pre class="hl">type</pre> is not provided,
+					<pre class="hl">url</pre> is fetched and
+					<pre class="hl">data</pre> is the text content of the result.
+					If
+					<pre class="hl">type</pre> is provided,
+					<pre class="hl">url</pre> is fetched as binary and it is interpreted according to
+					<pre class="hl">type</pre>:
+					<ul>
+						<li>
+							<pre class="hl">1</pre>: bits
+						</li>
+						<li>
+							<pre class="hl">8</pre>: unsigned 8-bit
+						</li>
+						<li>
+							<pre class="hl">¯8</pre>: signed 8-bit
+						</li>
+						<li>
+							<pre class="hl">16</pre>: unsigned 16-bit little endian
+						</li>
+						<li>
+							<pre class="hl">¯16</pre>: signed 16-bit little endian
+						</li>
+						<li>
+							<pre class="hl">0ᴊ16</pre>: unsigned 16-bit big endian
+						</li>
+						<li>
+							<pre class="hl">0ᴊ¯16</pre>: signed 16-bit big endian
+						</li>
+						<li>
+							<pre class="hl">32</pre>: unsigned 32-bit little endian
+						</li>
+						<li>
+							<pre class="hl">¯32</pre>: signed 32-bit little endian
+						</li>
+						<li>
+							<pre class="hl">0ᴊ32</pre>: unsigned 32-bit big endian
+						</li>
+						<li>
+							<pre class="hl">0ᴊ¯32</pre>: signed 32-bit big-endian
+						</li>
+						<li>
+							<pre class="hl">0.32</pre>: 32-bit float little endian
+						</li>
+						<li>
+							<pre class="hl">0ᴊ0.32</pre>: 32-bit float big endian
+						</li>
+						<li>
+							<pre class="hl">0.64</pre>: 64-bit float little endian
+						</li>
+						<li>
+							<pre class="hl">0ᴊ0.64</pre>: 64-bit float big endian
+						</li>
+					</ul>
+					64-bit integers are not provided as they cannot be losslessly loaded into float64s, TinyAPL's native
+					real number type.
+				</div>
+			</li>
+			<li>
+				<div>
+					<pre class="hl">⎕last</pre>,
+					<pre class="hl">⎕Last</pre>,
+					<pre class="hl">⎕_Last</pre>,
+					<pre class="hl">⎕_Last_</pre>: access the result of the last successful code ran.
+				</div>
+			</li>
 		</ul>
 	</div>
 	<div id="buttons"></div>

--- a/docs/interpreters/latest/index.html
+++ b/docs/interpreters/latest/index.html
@@ -204,13 +204,10 @@
 		<h1>Info</h1>
 		<h2>Inputting Glyphs</h2>
 		<p>
-			To input glyphs, you can either use the language bar, or the prefix key, which is <kbd
-				id="prefixkey"></kbd>.
+			To input glyphs, you can either use the language bar, or the prefix key, which is <kbd id="prefixkey"></kbd>.
 			The keyboard layout is shown in the image below.
-			To input a glyph in the middle column, press the prefix key once and then the corresponding key (shown in
-			the first column), holding <kbd>Shift</kbd> if it's in the upper row.
-			To input a glyph in the last column, press the prefix key twice and then the corresponding key, shifing as
-			before.
+			To input a glyph in the middle column, press the prefix key once and then the corresponding key (shown in the first column), holding <kbd>Shift</kbd> if it's in the upper row.
+			To input a glyph in the last column, press the prefix key twice and then the corresponding key, shifing as before.
 			Note that many (probably most) available glyphs currently correspond to no behavior and will error when ran.
 		</p>
 		<h2>Controls</h2>
@@ -218,202 +215,93 @@
 			To run your code, you can press <kbd>Enter</kbd> or the Run button.
 			To edit code you already ran, click on it.
 			Similarly, you can click on an output to put it into the input bar.
-			You can also scroll through previously ran code with <kbd>Shift</kbd>+<kbd>↑</kbd> and
-			<kbd>Shift</kbd>+<kbd>↓</kbd>
+			You can also scroll through previously ran code with <kbd>Shift</kbd>+<kbd>↑</kbd> and <kbd>Shift</kbd>+<kbd>↓</kbd>
 		</p>
 		<h2>Quads</h2>
 		<p>
 			In addition to all the quad names available normally in TinyAPL, there are additional ones:
 		</p>
 		<ul>
-			<li>
-				<div>
-					<pre class="hl">⎕Debug</pre>: acts exactly like
-					<pre class="hl">⊢</pre>,
-					except the input(s) are printed to the JavaScript console.
-					Useful if you want to create your own quads and want to look at the JS structure of arrays.
-				</div>
-			</li>
-			<li>
-				<div>
-					<pre class="hl">id←⎕CreateImage size</pre>: adds a blank image of size
-					<pre class="hl">size</pre>,
-					which can either be a scalar number (creating a square image) or a vector of
-					<pre class="hl">⟨height⋄width⟩</pre>.
-					Returns an
-					<pre class="hl">id</pre> (which is currently a number, but it's an implementation detail)
-					which can be used to update the image display.
-				</div>
-			</li>
-			<li>
-				<div>
-					<pre class="hl">[id] ⎕DisplayImage data</pre>: renders an image, either to a new display or to the
-					one indicated by
-					<pre class="hl">id</pre>.
-					<pre class="hl">data</pre> should be a real array of rank
-					<pre class="hl">2</pre> or
-					<pre class="hl">3</pre>
-					(if it's of rank
-					<pre class="hl">2</pre> a trailing unit axis is introduced as in
-					<pre class="hl">∧⍤0 data</pre>)
-					and the last axis must be of length
-					<pre class="hl">1</pre>,
-					<pre class="hl">2</pre>,
-					<pre class="hl">3</pre>,
-					<pre class="hl">4</pre>.
-					If the last axis has length
-					<pre class="hl">1</pre>,
-					<pre class="hl">data</pre> is interpreted as grayscale;
-					if it has length
-					<pre class="hl">2</pre>, it is interpreted as grayscale + alpha,
-					if it has length
-					<pre class="hl">3</pre>, it is interpreted as RGB,
-					if it has length
-					<pre class="hl">4</pre>, it is interpreted as RGBA.
-					In all cases,
-					<pre class="hl">0</pre> is the lowest value of the channel and
-					<pre class="hl">1</pre> is the highest value in the channel.
-					All data outside this range is clamped.
-				</div>
-			</li>
-			<div>
-				<li>
-					<pre class="hl">[delay] ⎕PlayAnimation data</pre>: plays an animation.
-					<pre class="hl">data</pre> should be a real array of rank
-					<pre class="hl">3</pre> or
-					<pre class="hl">4</pre>.
-					Each major cell of
-					<pre class="hl">data</pre> is used as a frame for the animation, in the way described for
-					<pre class="hl">⎕DisplayImage</pre>.
-					<pre class="hl">delay</pre> is the delay between frames in seconds and defaults to
-					<pre class="hl">0.1</pre>.
-				</li>
-			</div>
-			<li>
-				<div>
-					<pre class="hl">[mode] ⎕ScatterPlot data</pre>: renders a plot.
-					<pre class="hl">data</pre> should be a real array of rank
-					<pre class="hl">2</pre> or
-					<pre class="hl">3</pre>
-					(if it's of rank
-					<pre class="hl">2</pre> a leading unit axis is introduce as in
-					<pre class="hl">∧data</pre>)
-					and the last axis must be of length
-					<pre class="hl">2</pre>.
-					Matrices of
-					<pre class="hl">data</pre> are interpreted as scatter plot datasets, with each vector of the matrix
-					being a
-					<pre class="hl">⟨x⋄y⟩</pre> pair.
-					If
-					<pre class="hl">mode</pre> is provided, it must be one of
-					<pre class="hl">"markers"</pre>, which is the default and displays dots;
-					<pre class="hl">"lines"</pre>, which connects the provided points (and attempts to do so smoothly);
-					<pre class="hl">"lines+markers"</pre>, which displays both.
-				</div>
-			</li>
-			<li>
-				<div>
-					<pre class="hl">[start] fns ⎕_Graph end</pre>: graphs functions.
-					<pre class="hl">fns</pre> should be a function, a vector of functions, or a vector of pairs of
-					functions and labels.
-					The default labels are the representations of the functions.
-					<pre class="hl">start</pre> and
-					<pre class="hl">end</pre> are the start and end of the graph, respectively. The default
-					<pre class="hl">start</pre> is
-					<pre class="hl">0</pre>.
-					The function is evaluated at
-					<pre class="hl">501</pre> points evenly spaced between
-					<pre class="hl">start</pre> and
-					<pre class="hl">end</pre>.
-				</div>
-			</li>
-			<li>
-				<div>
-					<pre class="hl">[sampleRate] ⎕PlayAudio data</pre>: plays audio.
-					<pre class="hl">data</pre> should be a real array of rank
-					<pre class="hl">1</pre> or
-					<pre class="hl">2</pre>
-					(if it's of rank
-					<pre class="hl">1</pre> a leading unit axis is introduced as in
-					<pre class="hl">∧data</pre>).
-					Vectors of
-					<pre class="hl">data</pre> are channels containing samples.
-					<pre class="hl">sampleRate</pre> is the sample rate of
-					<pre class="hl">data</pre> and defaults to
-					<pre class="hl">44100</pre>.
-				</div>
-			</li>
-			<li>
-				<div>
-					<pre class="hl">data←[type] ⎕Fetch url</pre>: fetches data from the web.
-					<pre class="hl">url</pre> must be a string.
-					If
-					<pre class="hl">type</pre> is not provided,
-					<pre class="hl">url</pre> is fetched and
-					<pre class="hl">data</pre> is the text content of the result.
-					If
-					<pre class="hl">type</pre> is provided,
-					<pre class="hl">url</pre> is fetched as binary and it is interpreted according to
-					<pre class="hl">type</pre>:
-					<ul>
-						<li>
-							<pre class="hl">1</pre>: bits
-						</li>
-						<li>
-							<pre class="hl">8</pre>: unsigned 8-bit
-						</li>
-						<li>
-							<pre class="hl">¯8</pre>: signed 8-bit
-						</li>
-						<li>
-							<pre class="hl">16</pre>: unsigned 16-bit little endian
-						</li>
-						<li>
-							<pre class="hl">¯16</pre>: signed 16-bit little endian
-						</li>
-						<li>
-							<pre class="hl">0ᴊ16</pre>: unsigned 16-bit big endian
-						</li>
-						<li>
-							<pre class="hl">0ᴊ¯16</pre>: signed 16-bit big endian
-						</li>
-						<li>
-							<pre class="hl">32</pre>: unsigned 32-bit little endian
-						</li>
-						<li>
-							<pre class="hl">¯32</pre>: signed 32-bit little endian
-						</li>
-						<li>
-							<pre class="hl">0ᴊ32</pre>: unsigned 32-bit big endian
-						</li>
-						<li>
-							<pre class="hl">0ᴊ¯32</pre>: signed 32-bit big-endian
-						</li>
-						<li>
-							<pre class="hl">0.32</pre>: 32-bit float little endian
-						</li>
-						<li>
-							<pre class="hl">0ᴊ0.32</pre>: 32-bit float big endian
-						</li>
-						<li>
-							<pre class="hl">0.64</pre>: 64-bit float little endian
-						</li>
-						<li>
-							<pre class="hl">0ᴊ0.64</pre>: 64-bit float big endian
-						</li>
-					</ul>
-					64-bit integers are not provided as they cannot be losslessly loaded into float64s, TinyAPL's native
-					real number type.
-				</div>
-			</li>
-			<li>
-				<div>
-					<pre class="hl">⎕last</pre>,
-					<pre class="hl">⎕Last</pre>,
-					<pre class="hl">⎕_Last</pre>,
-					<pre class="hl">⎕_Last_</pre>: access the result of the last successful code ran.
-				</div>
-			</li>
+			<li><div>
+				<pre class="hl">⎕Debug</pre>: acts exactly like <pre class="hl">⊢</pre>,
+				except the input(s) are printed to the JavaScript console.
+				Useful if you want to create your own quads and want to look at the JS structure of arrays.
+			</div></li>
+			<li><div>
+				<pre class="hl">id←⎕CreateImage size</pre>: adds a blank image of size <pre class="hl">size</pre>,
+				which can either be a scalar number (creating a square image) or a vector of <pre class="hl">⟨height⋄width⟩</pre>.
+				Returns an <pre class="hl">id</pre> (which is currently a number, but it's an implementation detail)
+				which can be used to update the image display.
+			</div></li>
+			<li><div>
+				<pre class="hl">[id] ⎕DisplayImage data</pre>: renders an image, either to a new display or to the one indicated by <pre class="hl">id</pre>.
+				<pre class="hl">data</pre> should be a real array of rank <pre class="hl">2</pre> or <pre class="hl">3</pre>
+				(if it's of rank <pre class="hl">2</pre> a trailing unit axis is introduced as in <pre class="hl">∧⍤0 data</pre>)
+				and the last axis must be of length <pre class="hl">1</pre>, <pre class="hl">2</pre>, <pre class="hl">3</pre>, <pre class="hl">4</pre>.
+				If the last axis has length <pre class="hl">1</pre>, <pre class="hl">data</pre> is interpreted as grayscale;
+				if it has length <pre class="hl">2</pre>, it is interpreted as grayscale + alpha,
+				if it has length <pre class="hl">3</pre>, it is interpreted as RGB,
+				if it has length <pre class="hl">4</pre>, it is interpreted as RGBA.
+				In all cases, <pre class="hl">0</pre> is the lowest value of the channel and <pre class="hl">1</pre> is the highest value in the channel.
+				All data outside this range is clamped.
+			</div></li>
+			<div><li>
+				<pre class="hl">[delay] ⎕PlayAnimation data</pre>: plays an animation.
+				<pre class="hl">data</pre> should be a real array of rank <pre class="hl">3</pre> or <pre class="hl">4</pre>.
+				Each major cell of <pre class="hl">data</pre> is used as a frame for the animation, in the way described for <pre class="hl">⎕DisplayImage</pre>.
+				<pre class="hl">delay</pre> is the delay between frames in seconds and defaults to <pre class="hl">0.1</pre>.
+			</li></div>
+			<li><div>
+				<pre class="hl">[mode] ⎕ScatterPlot data</pre>: renders a plot.
+				<pre class="hl">data</pre> should be a real array of rank <pre class="hl">2</pre> or <pre class="hl">3</pre>
+				(if it's of rank <pre class="hl">2</pre> a leading unit axis is introduce as in <pre class="hl">∧data</pre>)
+				and the last axis must be of length <pre class="hl">2</pre>.
+				Matrices of <pre class="hl">data</pre> are interpreted as scatter plot datasets, with each vector of the matrix being a <pre class="hl">⟨x⋄y⟩</pre> pair.
+				If <pre class="hl">mode</pre> is provided, it must be one of <pre class="hl">"markers"</pre>, which is the default and displays dots;
+				<pre class="hl">"lines"</pre>, which connects the provided points (and attempts to do so smoothly);
+				<pre class="hl">"lines+markers"</pre>, which displays both.
+			</div></li>
+			<li><div>
+				<pre class="hl">[start] fns ⎕_Graph end</pre>: graphs functions.
+				<pre class="hl">fns</pre> should be a function, a vector of functions, or a vector of pairs of functions and labels.
+				The default labels are the representations of the functions.
+				<pre class="hl">start</pre> and <pre class="hl">end</pre> are the start and end of the graph, respectively. The default <pre class="hl">start</pre> is <pre class="hl">0</pre>.
+				The function is evaluated at <pre class="hl">501</pre> points evenly spaced between <pre class="hl">start</pre> and <pre class="hl">end</pre>.
+			</div></li>
+			<li><div>
+				<pre class="hl">[sampleRate] ⎕PlayAudio data</pre>: plays audio.
+				<pre class="hl">data</pre> should be a real array of rank <pre class="hl">1</pre> or <pre class="hl">2</pre>
+				(if it's of rank <pre class="hl">1</pre> a leading unit axis is introduced as in <pre class="hl">∧data</pre>).
+				Vectors of <pre class="hl">data</pre> are channels containing samples.
+				<pre class="hl">sampleRate</pre> is the sample rate of <pre class="hl">data</pre> and defaults to <pre class="hl">44100</pre>.
+			</div></li>
+			<li><div>
+				<pre class="hl">data←[type] ⎕Fetch url</pre>: fetches data from the web.
+				<pre class="hl">url</pre> must be a string.
+				If <pre class="hl">type</pre> is not provided, <pre class="hl">url</pre> is fetched and <pre class="hl">data</pre> is the text content of the result.
+				If <pre class="hl">type</pre> is provided, <pre class="hl">url</pre> is fetched as binary and it is interpreted according to <pre class="hl">type</pre>:
+				<ul>
+					<li><pre class="hl">1</pre>: bits</li>
+					<li><pre class="hl">8</pre>: unsigned 8-bit</li>
+					<li><pre class="hl">¯8</pre>: signed 8-bit</li>
+					<li><pre class="hl">16</pre>: unsigned 16-bit little endian</li>
+					<li><pre class="hl">¯16</pre>: signed 16-bit little endian</li>
+					<li><pre class="hl">0ᴊ16</pre>: unsigned 16-bit big endian</li>
+					<li><pre class="hl">0ᴊ¯16</pre>: signed 16-bit big endian</li>
+					<li><pre class="hl">32</pre>: unsigned 32-bit little endian</li>
+					<li><pre class="hl">¯32</pre>: signed 32-bit little endian</li>
+					<li><pre class="hl">0ᴊ32</pre>: unsigned 32-bit big endian</li>
+					<li><pre class="hl">0ᴊ¯32</pre>: signed 32-bit big-endian</li>
+					<li><pre class="hl">0.32</pre>: 32-bit float little endian</li>
+					<li><pre class="hl">0ᴊ0.32</pre>: 32-bit float big endian</li>
+					<li><pre class="hl">0.64</pre>: 64-bit float little endian</li>
+					<li><pre class="hl">0ᴊ0.64</pre>: 64-bit float big endian</li>
+				</ul>
+				64-bit integers are not provided as they cannot be losslessly loaded into float64s, TinyAPL's native real number type.
+			</div></li>
+			<li><div>
+				<pre class="hl">⎕last</pre>, <pre class="hl">⎕Last</pre>, <pre class="hl">⎕_Last</pre>, <pre class="hl">⎕_Last_</pre>: access the result of the last successful code ran.
+			</div></li>
 		</ul>
 	</div>
 	<div id="buttons"></div>

--- a/docs/interpreters/latest/index.html
+++ b/docs/interpreters/latest/index.html
@@ -131,6 +131,14 @@
 			margin-block: 2px;
 		}
 
+		.pad {
+			display: inline-flex;
+			width: 6ch;
+			height: 1ch;
+			justify-content: end;
+			padding-inline-end: 1ch;
+		}
+
 		.plot {
 			display: inline-block;
 		}
@@ -162,15 +170,10 @@
 			display: inline-block;
 			box-sizing: border-box;
 			animation: loader-rotation 1s linear infinite;
-
-			position: absolute;
-			left: 4ch;
-			top: 0.5ch;
 		}
 
 		.executed {
-			padding-left: 6ch;
-			position: relative;
+			display: flex;
 		}
 
 		@keyframes loader-rotation {

--- a/docs/interpreters/latest/index.js
+++ b/docs/interpreters/latest/index.js
@@ -296,8 +296,10 @@ async function runCode(code) {
     button.disabled = true;
     const in1 = div('executed', '');
     output.appendChild(in1);
+    const pad = span('pad', '');
     const loader = div('loader', '');
-    in1.appendChild(loader);
+    pad.appendChild(loader);
+    in1.appendChild(pad);
     in1.appendChild(selfClickableSpan('code', code));
     newDiv();
     io.rInput(async (what) => { d.innerText += what + '\n'; });

--- a/js/build-frontend-only.sh
+++ b/js/build-frontend-only.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# This script should be used when only modifying the frontend
+
+set -e
+
+if [[ $PWD == */js ]]; then
+	echo "build.sh must be ran in the root tinyapl directory"
+	exit 1
+fi
+
+cd js
+(tsc > /dev/null) || (echo "Compilation failed")
+cd ..
+
+echo "Compiled, copying files"
+
+cp -f js/*.html js/dist
+cp -f js/*.svg js/dist
+
+cp -f js/dist/* docs/interpreters/latest

--- a/js/index.html
+++ b/js/index.html
@@ -1,4 +1,5 @@
 <!doctype html>
+
 <head>
 	<meta charset="utf-8">
 	<title>TinyAPL Interpreter</title>
@@ -30,7 +31,7 @@
 			margin-bottom: 5px;
 			z-index: 100000000000;
 		}
-	
+
 		#buttons button {
 			font-family: var(--font-mono);
 		}
@@ -39,23 +40,23 @@
 			width: auto;
 			max-width: 100%;
 		}
-	
+
 		#output {
 			height: 90%;
 			font-family: var(--font-mono);
 		}
-		
+
 		#output * {
 			text-wrap: wrap;
 			overflow-wrap: break-word;
 		}
-		
-		#input, #highlighted {
+
+		#input,
+		#highlighted {
 			width: 97.5%;
 			font-family: var(--font-mono);
 			margin: 2.5px;
 			padding: 2.5px;
-			height: 1.25em;
 			grid-row: 1;
 			grid-column: 1;
 			overflow-x: auto;
@@ -76,12 +77,12 @@
 		#highlighted {
 			z-index: 0;
 		}
-		
+
 		#button {
 			width: auto;
 			font-family: var(--font-mono);
 		}
-		
+
 		#input-wrapper {
 			display: inline-grid;
 			width: 90%;
@@ -101,37 +102,29 @@
 			display: inline-block;
 			margin: 0;
 		}
-		
+
 		.char {
 			display: inline-block;
 			min-width: 1ch;
 		}
-		
+
 		.code {
 			color: grey;
 		}
-		
+
 		.error {
 			background: #ffcccc;
 			color: red;
 		}
-		
+
 		.result {
 			color: black;
 		}
-		
+
 		.quad {
 			color: dimgrey;
 		}
 
-		.pad {
-			display: inline-flex;
-			width: 6ch;
-			height: 1ch;
-			justify-content: end;
-			padding-inline-end: 1ch;
-		}
-		
 		.image {
 			border: 1px solid black;
 			display: block;
@@ -146,11 +139,16 @@
 			vertical-align: top;
 		}
 
-		table.vector, table.vector > tbody > tr, table.vector > tbody > tr > td, table.matrix, table.matrix > tbody > tr, table.matrix > tbody > tr > td {
+		table.vector,
+		table.vector>tbody>tr,
+		table.vector>tbody>tr>td,
+		table.matrix,
+		table.matrix>tbody>tr,
+		table.matrix>tbody>tr>td {
 			border: 2px solid black;
 			border-collapse: collapse;
 		}
-		
+
 		.struct ul {
 			margin-block: 0;
 		}
@@ -164,19 +162,35 @@
 			display: inline-block;
 			box-sizing: border-box;
 			animation: loader-rotation 1s linear infinite;
-    }
+
+			position: absolute;
+			left: 4ch;
+			top: 0.5ch;
+		}
+
+		.executed {
+			padding-left: 6ch;
+			position: relative;
+		}
 
 		@keyframes loader-rotation {
 			0% {
 				transform: rotate(0deg);
 			}
+
 			100% {
 				transform: rotate(360deg);
 			}
-    } 
-@keyframes l3 {to{transform: rotate(1turn)}}
+		}
+
+		@keyframes l3 {
+			to {
+				transform: rotate(1turn)
+			}
+		}
 	</style>
 </head>
+
 <body>
 	<h1 id="loading">Loading...</h1>
 	<input id="fancyarrays" type="checkbox" checked>
@@ -187,10 +201,13 @@
 		<h1>Info</h1>
 		<h2>Inputting Glyphs</h2>
 		<p>
-			To input glyphs, you can either use the language bar, or the prefix key, which is <kbd id="prefixkey"></kbd>.
+			To input glyphs, you can either use the language bar, or the prefix key, which is <kbd
+				id="prefixkey"></kbd>.
 			The keyboard layout is shown in the image below.
-			To input a glyph in the middle column, press the prefix key once and then the corresponding key (shown in the first column), holding <kbd>Shift</kbd> if it's in the upper row.
-			To input a glyph in the last column, press the prefix key twice and then the corresponding key, shifing as before.
+			To input a glyph in the middle column, press the prefix key once and then the corresponding key (shown in
+			the first column), holding <kbd>Shift</kbd> if it's in the upper row.
+			To input a glyph in the last column, press the prefix key twice and then the corresponding key, shifing as
+			before.
 			Note that many (probably most) available glyphs currently correspond to no behavior and will error when ran.
 		</p>
 		<h2>Controls</h2>
@@ -198,93 +215,202 @@
 			To run your code, you can press <kbd>Enter</kbd> or the Run button.
 			To edit code you already ran, click on it.
 			Similarly, you can click on an output to put it into the input bar.
-			You can also scroll through previously ran code with <kbd>Shift</kbd>+<kbd>↑</kbd> and <kbd>Shift</kbd>+<kbd>↓</kbd>
+			You can also scroll through previously ran code with <kbd>Shift</kbd>+<kbd>↑</kbd> and
+			<kbd>Shift</kbd>+<kbd>↓</kbd>
 		</p>
 		<h2>Quads</h2>
 		<p>
 			In addition to all the quad names available normally in TinyAPL, there are additional ones:
 		</p>
 		<ul>
-			<li><div>
-				<pre class="hl">⎕Debug</pre>: acts exactly like <pre class="hl">⊢</pre>,
-				except the input(s) are printed to the JavaScript console.
-				Useful if you want to create your own quads and want to look at the JS structure of arrays.
-			</div></li>
-			<li><div>
-				<pre class="hl">id←⎕CreateImage size</pre>: adds a blank image of size <pre class="hl">size</pre>,
-				which can either be a scalar number (creating a square image) or a vector of <pre class="hl">⟨height⋄width⟩</pre>.
-				Returns an <pre class="hl">id</pre> (which is currently a number, but it's an implementation detail)
-				which can be used to update the image display.
-			</div></li>
-			<li><div>
-				<pre class="hl">[id] ⎕DisplayImage data</pre>: renders an image, either to a new display or to the one indicated by <pre class="hl">id</pre>.
-				<pre class="hl">data</pre> should be a real array of rank <pre class="hl">2</pre> or <pre class="hl">3</pre>
-				(if it's of rank <pre class="hl">2</pre> a trailing unit axis is introduced as in <pre class="hl">∧⍤0 data</pre>)
-				and the last axis must be of length <pre class="hl">1</pre>, <pre class="hl">2</pre>, <pre class="hl">3</pre>, <pre class="hl">4</pre>.
-				If the last axis has length <pre class="hl">1</pre>, <pre class="hl">data</pre> is interpreted as grayscale;
-				if it has length <pre class="hl">2</pre>, it is interpreted as grayscale + alpha,
-				if it has length <pre class="hl">3</pre>, it is interpreted as RGB,
-				if it has length <pre class="hl">4</pre>, it is interpreted as RGBA.
-				In all cases, <pre class="hl">0</pre> is the lowest value of the channel and <pre class="hl">1</pre> is the highest value in the channel.
-				All data outside this range is clamped.
-			</div></li>
-			<div><li>
-				<pre class="hl">[delay] ⎕PlayAnimation data</pre>: plays an animation.
-				<pre class="hl">data</pre> should be a real array of rank <pre class="hl">3</pre> or <pre class="hl">4</pre>.
-				Each major cell of <pre class="hl">data</pre> is used as a frame for the animation, in the way described for <pre class="hl">⎕DisplayImage</pre>.
-				<pre class="hl">delay</pre> is the delay between frames in seconds and defaults to <pre class="hl">0.1</pre>.
-			</li></div>
-			<li><div>
-				<pre class="hl">[mode] ⎕ScatterPlot data</pre>: renders a plot.
-				<pre class="hl">data</pre> should be a real array of rank <pre class="hl">2</pre> or <pre class="hl">3</pre>
-				(if it's of rank <pre class="hl">2</pre> a leading unit axis is introduce as in <pre class="hl">∧data</pre>)
-				and the last axis must be of length <pre class="hl">2</pre>.
-				Matrices of <pre class="hl">data</pre> are interpreted as scatter plot datasets, with each vector of the matrix being a <pre class="hl">⟨x⋄y⟩</pre> pair.
-				If <pre class="hl">mode</pre> is provided, it must be one of <pre class="hl">"markers"</pre>, which is the default and displays dots;
-				<pre class="hl">"lines"</pre>, which connects the provided points (and attempts to do so smoothly);
-				<pre class="hl">"lines+markers"</pre>, which displays both.
-			</div></li>
-			<li><div>
-				<pre class="hl">[start] fns ⎕_Graph end</pre>: graphs functions.
-				<pre class="hl">fns</pre> should be a function, a vector of functions, or a vector of pairs of functions and labels.
-				The default labels are the representations of the functions.
-				<pre class="hl">start</pre> and <pre class="hl">end</pre> are the start and end of the graph, respectively. The default <pre class="hl">start</pre> is <pre class="hl">0</pre>.
-				The function is evaluated at <pre class="hl">501</pre> points evenly spaced between <pre class="hl">start</pre> and <pre class="hl">end</pre>.
-			</div></li>
-			<li><div>
-				<pre class="hl">[sampleRate] ⎕PlayAudio data</pre>: plays audio.
-				<pre class="hl">data</pre> should be a real array of rank <pre class="hl">1</pre> or <pre class="hl">2</pre>
-				(if it's of rank <pre class="hl">1</pre> a leading unit axis is introduced as in <pre class="hl">∧data</pre>).
-				Vectors of <pre class="hl">data</pre> are channels containing samples.
-				<pre class="hl">sampleRate</pre> is the sample rate of <pre class="hl">data</pre> and defaults to <pre class="hl">44100</pre>.
-			</div></li>
-			<li><div>
-				<pre class="hl">data←[type] ⎕Fetch url</pre>: fetches data from the web.
-				<pre class="hl">url</pre> must be a string.
-				If <pre class="hl">type</pre> is not provided, <pre class="hl">url</pre> is fetched and <pre class="hl">data</pre> is the text content of the result.
-				If <pre class="hl">type</pre> is provided, <pre class="hl">url</pre> is fetched as binary and it is interpreted according to <pre class="hl">type</pre>:
-				<ul>
-					<li><pre class="hl">1</pre>: bits</li>
-					<li><pre class="hl">8</pre>: unsigned 8-bit</li>
-					<li><pre class="hl">¯8</pre>: signed 8-bit</li>
-					<li><pre class="hl">16</pre>: unsigned 16-bit little endian</li>
-					<li><pre class="hl">¯16</pre>: signed 16-bit little endian</li>
-					<li><pre class="hl">0ᴊ16</pre>: unsigned 16-bit big endian</li>
-					<li><pre class="hl">0ᴊ¯16</pre>: signed 16-bit big endian</li>
-					<li><pre class="hl">32</pre>: unsigned 32-bit little endian</li>
-					<li><pre class="hl">¯32</pre>: signed 32-bit little endian</li>
-					<li><pre class="hl">0ᴊ32</pre>: unsigned 32-bit big endian</li>
-					<li><pre class="hl">0ᴊ¯32</pre>: signed 32-bit big-endian</li>
-					<li><pre class="hl">0.32</pre>: 32-bit float little endian</li>
-					<li><pre class="hl">0ᴊ0.32</pre>: 32-bit float big endian</li>
-					<li><pre class="hl">0.64</pre>: 64-bit float little endian</li>
-					<li><pre class="hl">0ᴊ0.64</pre>: 64-bit float big endian</li>
-				</ul>
-				64-bit integers are not provided as they cannot be losslessly loaded into float64s, TinyAPL's native real number type.
-			</div></li>
-			<li><div>
-				<pre class="hl">⎕last</pre>, <pre class="hl">⎕Last</pre>, <pre class="hl">⎕_Last</pre>, <pre class="hl">⎕_Last_</pre>: access the result of the last successful code ran.
-			</div></li>
+			<li>
+				<div>
+					<pre class="hl">⎕Debug</pre>: acts exactly like
+					<pre class="hl">⊢</pre>,
+					except the input(s) are printed to the JavaScript console.
+					Useful if you want to create your own quads and want to look at the JS structure of arrays.
+				</div>
+			</li>
+			<li>
+				<div>
+					<pre class="hl">id←⎕CreateImage size</pre>: adds a blank image of size
+					<pre class="hl">size</pre>,
+					which can either be a scalar number (creating a square image) or a vector of
+					<pre class="hl">⟨height⋄width⟩</pre>.
+					Returns an
+					<pre class="hl">id</pre> (which is currently a number, but it's an implementation detail)
+					which can be used to update the image display.
+				</div>
+			</li>
+			<li>
+				<div>
+					<pre class="hl">[id] ⎕DisplayImage data</pre>: renders an image, either to a new display or to the
+					one indicated by
+					<pre class="hl">id</pre>.
+					<pre class="hl">data</pre> should be a real array of rank
+					<pre class="hl">2</pre> or
+					<pre class="hl">3</pre>
+					(if it's of rank
+					<pre class="hl">2</pre> a trailing unit axis is introduced as in
+					<pre class="hl">∧⍤0 data</pre>)
+					and the last axis must be of length
+					<pre class="hl">1</pre>,
+					<pre class="hl">2</pre>,
+					<pre class="hl">3</pre>,
+					<pre class="hl">4</pre>.
+					If the last axis has length
+					<pre class="hl">1</pre>,
+					<pre class="hl">data</pre> is interpreted as grayscale;
+					if it has length
+					<pre class="hl">2</pre>, it is interpreted as grayscale + alpha,
+					if it has length
+					<pre class="hl">3</pre>, it is interpreted as RGB,
+					if it has length
+					<pre class="hl">4</pre>, it is interpreted as RGBA.
+					In all cases,
+					<pre class="hl">0</pre> is the lowest value of the channel and
+					<pre class="hl">1</pre> is the highest value in the channel.
+					All data outside this range is clamped.
+				</div>
+			</li>
+			<div>
+				<li>
+					<pre class="hl">[delay] ⎕PlayAnimation data</pre>: plays an animation.
+					<pre class="hl">data</pre> should be a real array of rank
+					<pre class="hl">3</pre> or
+					<pre class="hl">4</pre>.
+					Each major cell of
+					<pre class="hl">data</pre> is used as a frame for the animation, in the way described for
+					<pre class="hl">⎕DisplayImage</pre>.
+					<pre class="hl">delay</pre> is the delay between frames in seconds and defaults to
+					<pre class="hl">0.1</pre>.
+				</li>
+			</div>
+			<li>
+				<div>
+					<pre class="hl">[mode] ⎕ScatterPlot data</pre>: renders a plot.
+					<pre class="hl">data</pre> should be a real array of rank
+					<pre class="hl">2</pre> or
+					<pre class="hl">3</pre>
+					(if it's of rank
+					<pre class="hl">2</pre> a leading unit axis is introduce as in
+					<pre class="hl">∧data</pre>)
+					and the last axis must be of length
+					<pre class="hl">2</pre>.
+					Matrices of
+					<pre class="hl">data</pre> are interpreted as scatter plot datasets, with each vector of the matrix
+					being a
+					<pre class="hl">⟨x⋄y⟩</pre> pair.
+					If
+					<pre class="hl">mode</pre> is provided, it must be one of
+					<pre class="hl">"markers"</pre>, which is the default and displays dots;
+					<pre class="hl">"lines"</pre>, which connects the provided points (and attempts to do so smoothly);
+					<pre class="hl">"lines+markers"</pre>, which displays both.
+				</div>
+			</li>
+			<li>
+				<div>
+					<pre class="hl">[start] fns ⎕_Graph end</pre>: graphs functions.
+					<pre class="hl">fns</pre> should be a function, a vector of functions, or a vector of pairs of
+					functions and labels.
+					The default labels are the representations of the functions.
+					<pre class="hl">start</pre> and
+					<pre class="hl">end</pre> are the start and end of the graph, respectively. The default
+					<pre class="hl">start</pre> is
+					<pre class="hl">0</pre>.
+					The function is evaluated at
+					<pre class="hl">501</pre> points evenly spaced between
+					<pre class="hl">start</pre> and
+					<pre class="hl">end</pre>.
+				</div>
+			</li>
+			<li>
+				<div>
+					<pre class="hl">[sampleRate] ⎕PlayAudio data</pre>: plays audio.
+					<pre class="hl">data</pre> should be a real array of rank
+					<pre class="hl">1</pre> or
+					<pre class="hl">2</pre>
+					(if it's of rank
+					<pre class="hl">1</pre> a leading unit axis is introduced as in
+					<pre class="hl">∧data</pre>).
+					Vectors of
+					<pre class="hl">data</pre> are channels containing samples.
+					<pre class="hl">sampleRate</pre> is the sample rate of
+					<pre class="hl">data</pre> and defaults to
+					<pre class="hl">44100</pre>.
+				</div>
+			</li>
+			<li>
+				<div>
+					<pre class="hl">data←[type] ⎕Fetch url</pre>: fetches data from the web.
+					<pre class="hl">url</pre> must be a string.
+					If
+					<pre class="hl">type</pre> is not provided,
+					<pre class="hl">url</pre> is fetched and
+					<pre class="hl">data</pre> is the text content of the result.
+					If
+					<pre class="hl">type</pre> is provided,
+					<pre class="hl">url</pre> is fetched as binary and it is interpreted according to
+					<pre class="hl">type</pre>:
+					<ul>
+						<li>
+							<pre class="hl">1</pre>: bits
+						</li>
+						<li>
+							<pre class="hl">8</pre>: unsigned 8-bit
+						</li>
+						<li>
+							<pre class="hl">¯8</pre>: signed 8-bit
+						</li>
+						<li>
+							<pre class="hl">16</pre>: unsigned 16-bit little endian
+						</li>
+						<li>
+							<pre class="hl">¯16</pre>: signed 16-bit little endian
+						</li>
+						<li>
+							<pre class="hl">0ᴊ16</pre>: unsigned 16-bit big endian
+						</li>
+						<li>
+							<pre class="hl">0ᴊ¯16</pre>: signed 16-bit big endian
+						</li>
+						<li>
+							<pre class="hl">32</pre>: unsigned 32-bit little endian
+						</li>
+						<li>
+							<pre class="hl">¯32</pre>: signed 32-bit little endian
+						</li>
+						<li>
+							<pre class="hl">0ᴊ32</pre>: unsigned 32-bit big endian
+						</li>
+						<li>
+							<pre class="hl">0ᴊ¯32</pre>: signed 32-bit big-endian
+						</li>
+						<li>
+							<pre class="hl">0.32</pre>: 32-bit float little endian
+						</li>
+						<li>
+							<pre class="hl">0ᴊ0.32</pre>: 32-bit float big endian
+						</li>
+						<li>
+							<pre class="hl">0.64</pre>: 64-bit float little endian
+						</li>
+						<li>
+							<pre class="hl">0ᴊ0.64</pre>: 64-bit float big endian
+						</li>
+					</ul>
+					64-bit integers are not provided as they cannot be losslessly loaded into float64s, TinyAPL's native
+					real number type.
+				</div>
+			</li>
+			<li>
+				<div>
+					<pre class="hl">⎕last</pre>,
+					<pre class="hl">⎕Last</pre>,
+					<pre class="hl">⎕_Last</pre>,
+					<pre class="hl">⎕_Last_</pre>: access the result of the last successful code ran.
+				</div>
+			</li>
 		</ul>
 	</div>
 	<div id="buttons"></div>

--- a/js/index.html
+++ b/js/index.html
@@ -204,13 +204,10 @@
 		<h1>Info</h1>
 		<h2>Inputting Glyphs</h2>
 		<p>
-			To input glyphs, you can either use the language bar, or the prefix key, which is <kbd
-				id="prefixkey"></kbd>.
+			To input glyphs, you can either use the language bar, or the prefix key, which is <kbd id="prefixkey"></kbd>.
 			The keyboard layout is shown in the image below.
-			To input a glyph in the middle column, press the prefix key once and then the corresponding key (shown in
-			the first column), holding <kbd>Shift</kbd> if it's in the upper row.
-			To input a glyph in the last column, press the prefix key twice and then the corresponding key, shifing as
-			before.
+			To input a glyph in the middle column, press the prefix key once and then the corresponding key (shown in the first column), holding <kbd>Shift</kbd> if it's in the upper row.
+			To input a glyph in the last column, press the prefix key twice and then the corresponding key, shifing as before.
 			Note that many (probably most) available glyphs currently correspond to no behavior and will error when ran.
 		</p>
 		<h2>Controls</h2>
@@ -218,202 +215,93 @@
 			To run your code, you can press <kbd>Enter</kbd> or the Run button.
 			To edit code you already ran, click on it.
 			Similarly, you can click on an output to put it into the input bar.
-			You can also scroll through previously ran code with <kbd>Shift</kbd>+<kbd>↑</kbd> and
-			<kbd>Shift</kbd>+<kbd>↓</kbd>
+			You can also scroll through previously ran code with <kbd>Shift</kbd>+<kbd>↑</kbd> and <kbd>Shift</kbd>+<kbd>↓</kbd>
 		</p>
 		<h2>Quads</h2>
 		<p>
 			In addition to all the quad names available normally in TinyAPL, there are additional ones:
 		</p>
 		<ul>
-			<li>
-				<div>
-					<pre class="hl">⎕Debug</pre>: acts exactly like
-					<pre class="hl">⊢</pre>,
-					except the input(s) are printed to the JavaScript console.
-					Useful if you want to create your own quads and want to look at the JS structure of arrays.
-				</div>
-			</li>
-			<li>
-				<div>
-					<pre class="hl">id←⎕CreateImage size</pre>: adds a blank image of size
-					<pre class="hl">size</pre>,
-					which can either be a scalar number (creating a square image) or a vector of
-					<pre class="hl">⟨height⋄width⟩</pre>.
-					Returns an
-					<pre class="hl">id</pre> (which is currently a number, but it's an implementation detail)
-					which can be used to update the image display.
-				</div>
-			</li>
-			<li>
-				<div>
-					<pre class="hl">[id] ⎕DisplayImage data</pre>: renders an image, either to a new display or to the
-					one indicated by
-					<pre class="hl">id</pre>.
-					<pre class="hl">data</pre> should be a real array of rank
-					<pre class="hl">2</pre> or
-					<pre class="hl">3</pre>
-					(if it's of rank
-					<pre class="hl">2</pre> a trailing unit axis is introduced as in
-					<pre class="hl">∧⍤0 data</pre>)
-					and the last axis must be of length
-					<pre class="hl">1</pre>,
-					<pre class="hl">2</pre>,
-					<pre class="hl">3</pre>,
-					<pre class="hl">4</pre>.
-					If the last axis has length
-					<pre class="hl">1</pre>,
-					<pre class="hl">data</pre> is interpreted as grayscale;
-					if it has length
-					<pre class="hl">2</pre>, it is interpreted as grayscale + alpha,
-					if it has length
-					<pre class="hl">3</pre>, it is interpreted as RGB,
-					if it has length
-					<pre class="hl">4</pre>, it is interpreted as RGBA.
-					In all cases,
-					<pre class="hl">0</pre> is the lowest value of the channel and
-					<pre class="hl">1</pre> is the highest value in the channel.
-					All data outside this range is clamped.
-				</div>
-			</li>
-			<div>
-				<li>
-					<pre class="hl">[delay] ⎕PlayAnimation data</pre>: plays an animation.
-					<pre class="hl">data</pre> should be a real array of rank
-					<pre class="hl">3</pre> or
-					<pre class="hl">4</pre>.
-					Each major cell of
-					<pre class="hl">data</pre> is used as a frame for the animation, in the way described for
-					<pre class="hl">⎕DisplayImage</pre>.
-					<pre class="hl">delay</pre> is the delay between frames in seconds and defaults to
-					<pre class="hl">0.1</pre>.
-				</li>
-			</div>
-			<li>
-				<div>
-					<pre class="hl">[mode] ⎕ScatterPlot data</pre>: renders a plot.
-					<pre class="hl">data</pre> should be a real array of rank
-					<pre class="hl">2</pre> or
-					<pre class="hl">3</pre>
-					(if it's of rank
-					<pre class="hl">2</pre> a leading unit axis is introduce as in
-					<pre class="hl">∧data</pre>)
-					and the last axis must be of length
-					<pre class="hl">2</pre>.
-					Matrices of
-					<pre class="hl">data</pre> are interpreted as scatter plot datasets, with each vector of the matrix
-					being a
-					<pre class="hl">⟨x⋄y⟩</pre> pair.
-					If
-					<pre class="hl">mode</pre> is provided, it must be one of
-					<pre class="hl">"markers"</pre>, which is the default and displays dots;
-					<pre class="hl">"lines"</pre>, which connects the provided points (and attempts to do so smoothly);
-					<pre class="hl">"lines+markers"</pre>, which displays both.
-				</div>
-			</li>
-			<li>
-				<div>
-					<pre class="hl">[start] fns ⎕_Graph end</pre>: graphs functions.
-					<pre class="hl">fns</pre> should be a function, a vector of functions, or a vector of pairs of
-					functions and labels.
-					The default labels are the representations of the functions.
-					<pre class="hl">start</pre> and
-					<pre class="hl">end</pre> are the start and end of the graph, respectively. The default
-					<pre class="hl">start</pre> is
-					<pre class="hl">0</pre>.
-					The function is evaluated at
-					<pre class="hl">501</pre> points evenly spaced between
-					<pre class="hl">start</pre> and
-					<pre class="hl">end</pre>.
-				</div>
-			</li>
-			<li>
-				<div>
-					<pre class="hl">[sampleRate] ⎕PlayAudio data</pre>: plays audio.
-					<pre class="hl">data</pre> should be a real array of rank
-					<pre class="hl">1</pre> or
-					<pre class="hl">2</pre>
-					(if it's of rank
-					<pre class="hl">1</pre> a leading unit axis is introduced as in
-					<pre class="hl">∧data</pre>).
-					Vectors of
-					<pre class="hl">data</pre> are channels containing samples.
-					<pre class="hl">sampleRate</pre> is the sample rate of
-					<pre class="hl">data</pre> and defaults to
-					<pre class="hl">44100</pre>.
-				</div>
-			</li>
-			<li>
-				<div>
-					<pre class="hl">data←[type] ⎕Fetch url</pre>: fetches data from the web.
-					<pre class="hl">url</pre> must be a string.
-					If
-					<pre class="hl">type</pre> is not provided,
-					<pre class="hl">url</pre> is fetched and
-					<pre class="hl">data</pre> is the text content of the result.
-					If
-					<pre class="hl">type</pre> is provided,
-					<pre class="hl">url</pre> is fetched as binary and it is interpreted according to
-					<pre class="hl">type</pre>:
-					<ul>
-						<li>
-							<pre class="hl">1</pre>: bits
-						</li>
-						<li>
-							<pre class="hl">8</pre>: unsigned 8-bit
-						</li>
-						<li>
-							<pre class="hl">¯8</pre>: signed 8-bit
-						</li>
-						<li>
-							<pre class="hl">16</pre>: unsigned 16-bit little endian
-						</li>
-						<li>
-							<pre class="hl">¯16</pre>: signed 16-bit little endian
-						</li>
-						<li>
-							<pre class="hl">0ᴊ16</pre>: unsigned 16-bit big endian
-						</li>
-						<li>
-							<pre class="hl">0ᴊ¯16</pre>: signed 16-bit big endian
-						</li>
-						<li>
-							<pre class="hl">32</pre>: unsigned 32-bit little endian
-						</li>
-						<li>
-							<pre class="hl">¯32</pre>: signed 32-bit little endian
-						</li>
-						<li>
-							<pre class="hl">0ᴊ32</pre>: unsigned 32-bit big endian
-						</li>
-						<li>
-							<pre class="hl">0ᴊ¯32</pre>: signed 32-bit big-endian
-						</li>
-						<li>
-							<pre class="hl">0.32</pre>: 32-bit float little endian
-						</li>
-						<li>
-							<pre class="hl">0ᴊ0.32</pre>: 32-bit float big endian
-						</li>
-						<li>
-							<pre class="hl">0.64</pre>: 64-bit float little endian
-						</li>
-						<li>
-							<pre class="hl">0ᴊ0.64</pre>: 64-bit float big endian
-						</li>
-					</ul>
-					64-bit integers are not provided as they cannot be losslessly loaded into float64s, TinyAPL's native
-					real number type.
-				</div>
-			</li>
-			<li>
-				<div>
-					<pre class="hl">⎕last</pre>,
-					<pre class="hl">⎕Last</pre>,
-					<pre class="hl">⎕_Last</pre>,
-					<pre class="hl">⎕_Last_</pre>: access the result of the last successful code ran.
-				</div>
-			</li>
+			<li><div>
+				<pre class="hl">⎕Debug</pre>: acts exactly like <pre class="hl">⊢</pre>,
+				except the input(s) are printed to the JavaScript console.
+				Useful if you want to create your own quads and want to look at the JS structure of arrays.
+			</div></li>
+			<li><div>
+				<pre class="hl">id←⎕CreateImage size</pre>: adds a blank image of size <pre class="hl">size</pre>,
+				which can either be a scalar number (creating a square image) or a vector of <pre class="hl">⟨height⋄width⟩</pre>.
+				Returns an <pre class="hl">id</pre> (which is currently a number, but it's an implementation detail)
+				which can be used to update the image display.
+			</div></li>
+			<li><div>
+				<pre class="hl">[id] ⎕DisplayImage data</pre>: renders an image, either to a new display or to the one indicated by <pre class="hl">id</pre>.
+				<pre class="hl">data</pre> should be a real array of rank <pre class="hl">2</pre> or <pre class="hl">3</pre>
+				(if it's of rank <pre class="hl">2</pre> a trailing unit axis is introduced as in <pre class="hl">∧⍤0 data</pre>)
+				and the last axis must be of length <pre class="hl">1</pre>, <pre class="hl">2</pre>, <pre class="hl">3</pre>, <pre class="hl">4</pre>.
+				If the last axis has length <pre class="hl">1</pre>, <pre class="hl">data</pre> is interpreted as grayscale;
+				if it has length <pre class="hl">2</pre>, it is interpreted as grayscale + alpha,
+				if it has length <pre class="hl">3</pre>, it is interpreted as RGB,
+				if it has length <pre class="hl">4</pre>, it is interpreted as RGBA.
+				In all cases, <pre class="hl">0</pre> is the lowest value of the channel and <pre class="hl">1</pre> is the highest value in the channel.
+				All data outside this range is clamped.
+			</div></li>
+			<div><li>
+				<pre class="hl">[delay] ⎕PlayAnimation data</pre>: plays an animation.
+				<pre class="hl">data</pre> should be a real array of rank <pre class="hl">3</pre> or <pre class="hl">4</pre>.
+				Each major cell of <pre class="hl">data</pre> is used as a frame for the animation, in the way described for <pre class="hl">⎕DisplayImage</pre>.
+				<pre class="hl">delay</pre> is the delay between frames in seconds and defaults to <pre class="hl">0.1</pre>.
+			</li></div>
+			<li><div>
+				<pre class="hl">[mode] ⎕ScatterPlot data</pre>: renders a plot.
+				<pre class="hl">data</pre> should be a real array of rank <pre class="hl">2</pre> or <pre class="hl">3</pre>
+				(if it's of rank <pre class="hl">2</pre> a leading unit axis is introduce as in <pre class="hl">∧data</pre>)
+				and the last axis must be of length <pre class="hl">2</pre>.
+				Matrices of <pre class="hl">data</pre> are interpreted as scatter plot datasets, with each vector of the matrix being a <pre class="hl">⟨x⋄y⟩</pre> pair.
+				If <pre class="hl">mode</pre> is provided, it must be one of <pre class="hl">"markers"</pre>, which is the default and displays dots;
+				<pre class="hl">"lines"</pre>, which connects the provided points (and attempts to do so smoothly);
+				<pre class="hl">"lines+markers"</pre>, which displays both.
+			</div></li>
+			<li><div>
+				<pre class="hl">[start] fns ⎕_Graph end</pre>: graphs functions.
+				<pre class="hl">fns</pre> should be a function, a vector of functions, or a vector of pairs of functions and labels.
+				The default labels are the representations of the functions.
+				<pre class="hl">start</pre> and <pre class="hl">end</pre> are the start and end of the graph, respectively. The default <pre class="hl">start</pre> is <pre class="hl">0</pre>.
+				The function is evaluated at <pre class="hl">501</pre> points evenly spaced between <pre class="hl">start</pre> and <pre class="hl">end</pre>.
+			</div></li>
+			<li><div>
+				<pre class="hl">[sampleRate] ⎕PlayAudio data</pre>: plays audio.
+				<pre class="hl">data</pre> should be a real array of rank <pre class="hl">1</pre> or <pre class="hl">2</pre>
+				(if it's of rank <pre class="hl">1</pre> a leading unit axis is introduced as in <pre class="hl">∧data</pre>).
+				Vectors of <pre class="hl">data</pre> are channels containing samples.
+				<pre class="hl">sampleRate</pre> is the sample rate of <pre class="hl">data</pre> and defaults to <pre class="hl">44100</pre>.
+			</div></li>
+			<li><div>
+				<pre class="hl">data←[type] ⎕Fetch url</pre>: fetches data from the web.
+				<pre class="hl">url</pre> must be a string.
+				If <pre class="hl">type</pre> is not provided, <pre class="hl">url</pre> is fetched and <pre class="hl">data</pre> is the text content of the result.
+				If <pre class="hl">type</pre> is provided, <pre class="hl">url</pre> is fetched as binary and it is interpreted according to <pre class="hl">type</pre>:
+				<ul>
+					<li><pre class="hl">1</pre>: bits</li>
+					<li><pre class="hl">8</pre>: unsigned 8-bit</li>
+					<li><pre class="hl">¯8</pre>: signed 8-bit</li>
+					<li><pre class="hl">16</pre>: unsigned 16-bit little endian</li>
+					<li><pre class="hl">¯16</pre>: signed 16-bit little endian</li>
+					<li><pre class="hl">0ᴊ16</pre>: unsigned 16-bit big endian</li>
+					<li><pre class="hl">0ᴊ¯16</pre>: signed 16-bit big endian</li>
+					<li><pre class="hl">32</pre>: unsigned 32-bit little endian</li>
+					<li><pre class="hl">¯32</pre>: signed 32-bit little endian</li>
+					<li><pre class="hl">0ᴊ32</pre>: unsigned 32-bit big endian</li>
+					<li><pre class="hl">0ᴊ¯32</pre>: signed 32-bit big-endian</li>
+					<li><pre class="hl">0.32</pre>: 32-bit float little endian</li>
+					<li><pre class="hl">0ᴊ0.32</pre>: 32-bit float big endian</li>
+					<li><pre class="hl">0.64</pre>: 64-bit float little endian</li>
+					<li><pre class="hl">0ᴊ0.64</pre>: 64-bit float big endian</li>
+				</ul>
+				64-bit integers are not provided as they cannot be losslessly loaded into float64s, TinyAPL's native real number type.
+			</div></li>
+			<li><div>
+				<pre class="hl">⎕last</pre>, <pre class="hl">⎕Last</pre>, <pre class="hl">⎕_Last</pre>, <pre class="hl">⎕_Last_</pre>: access the result of the last successful code ran.
+			</div></li>
 		</ul>
 	</div>
 	<div id="buttons"></div>

--- a/js/index.html
+++ b/js/index.html
@@ -131,6 +131,14 @@
 			margin-block: 2px;
 		}
 
+		.pad {
+			display: inline-flex;
+			width: 6ch;
+			height: 1ch;
+			justify-content: end;
+			padding-inline-end: 1ch;
+		}
+
 		.plot {
 			display: inline-block;
 		}
@@ -162,15 +170,10 @@
 			display: inline-block;
 			box-sizing: border-box;
 			animation: loader-rotation 1s linear infinite;
-
-			position: absolute;
-			left: 4ch;
-			top: 0.5ch;
 		}
 
 		.executed {
-			padding-left: 6ch;
-			position: relative;
+			display: flex;
 		}
 
 		@keyframes loader-rotation {

--- a/js/index.ts
+++ b/js/index.ts
@@ -306,8 +306,10 @@ async function runCode(code: string) {
 	button.disabled = true;
 	const in1 = div('executed', '');
 	output.appendChild(in1);
+	const pad = span('pad', '');
 	const loader = div('loader', '');
-	in1.appendChild(loader);
+	pad.appendChild(loader);
+	in1.appendChild(pad);
 	in1.appendChild(selfClickableSpan('code', code));
 	newDiv();
 	io.rInput(async what => { d.innerText += what + '\n'; });

--- a/js/index.ts
+++ b/js/index.ts
@@ -12,7 +12,7 @@ declare const Plotly: typeof import('plotly.js');
 
 const buttons = document.querySelector<HTMLDivElement>('#buttons')!;
 const output = document.querySelector<HTMLPreElement>('#output')!;
-const input = document.querySelector<HTMLInputElement>('#input')!;
+const input = document.querySelector<HTMLTextAreaElement>('#input')!;
 const highlighted = document.querySelector<HTMLPreElement>('#highlighted')!;
 const button = document.querySelector<HTMLButtonElement>('#button')!;
 const infobutton = document.querySelector<HTMLButtonElement>('#infobutton')!;
@@ -97,6 +97,13 @@ async function highlight(code: string, output: HTMLPreElement) {
 	const pairs = zip(await tinyapl.splitString(code), await tinyapl.highlight(code));
 	output.innerHTML = '';
 	for (const [t, c] of pairs) {
+		if (t === '\n') {
+			output.appendChild(document.createElement('br'));
+			// Appending a zero-width non-joiner forces the line break to be rendered
+			// and the highlighted text to expand properly
+			output.appendChild(document.createTextNode('\u200c'));
+			continue;
+		}
 		const span = document.createElement('span');
 		span.className = 'char ' + tinyapl.colorsInv[c];
 		span.style.color = colors[tinyapl.colorsInv[c] as keyof typeof colors];
@@ -267,17 +274,17 @@ async function fancyShow(result: tinyapl.Value, depth: number = 0): Promise<Node
 
 async function runCode(code: string) {
 	let d: HTMLDivElement;
-	
+
 	const endDiv = () => {
-		if (d.textContent!.trim() === '') try { output.removeChild(d); } catch (_) {};
+		if (d.textContent!.trim() === '') try { output.removeChild(d); } catch (_) { };
 		if (d.textContent!.at(-1) === '\n') d.textContent = d.textContent!.slice(0, -1);
 	};
-	
+
 	const newDiv = () => {
 		d = div('quad', '');
 		output.appendChild(d);
 	};
-	
+
 	const createImage = (id: number | undefined, width: number, height: number) => {
 		endDiv();
 		const canvas = document.createElement('canvas');
@@ -295,14 +302,12 @@ async function runCode(code: string) {
 
 	ranCode.push(code);
 	lastIndex = ranCode.length;
-	
+
 	button.disabled = true;
-	const in1 = div('', '');
+	const in1 = div('executed', '');
 	output.appendChild(in1);
-	const pad = span('pad', '');
 	const loader = div('loader', '');
-	pad.appendChild(loader);
-	in1.appendChild(pad);
+	in1.appendChild(loader);
 	in1.appendChild(selfClickableSpan('code', code));
 	newDiv();
 	io.rInput(async what => { d.innerText += what + '\n'; });
@@ -348,12 +353,12 @@ async function runCode(code: string) {
 	quads.rPlayAudio(async buf => {
 		endDiv();
 		const audio = document.createElement('audio');
-  	audio.controls = true;
+		audio.controls = true;
 		audio.autoplay = true;
-  	const blob = new Blob([buf], { type: 'audio/wav' });
-  	const url = URL.createObjectURL(blob);
-  	audio.src = url;
-  	output.appendChild(audio);
+		const blob = new Blob([buf], { type: 'audio/wav' });
+		const url = URL.createObjectURL(blob);
+		audio.src = url;
+		output.appendChild(audio);
 		newDiv();
 	});
 	const result = await tinyapl.runCode(context, code);
@@ -402,7 +407,7 @@ input.addEventListener('keydown', evt => {
 			keyboardState = 0;
 			evt.preventDefault();
 		}
-	} else if (evt.key === 'Enter') {
+	} else if (evt.key === 'Enter' && !evt.shiftKey) {
 		evt.preventDefault();
 		if (!button.disabled) return run();
 	} else if (evt.key === 'ArrowUp' && evt.shiftKey && !evt.altKey && !evt.ctrlKey && !evt.metaKey) {
@@ -427,6 +432,7 @@ for (const k of document.querySelectorAll<HTMLPreElement>('.hl')) highlight(k.te
 document.querySelector('#loading')!.remove();
 button.disabled = false;
 infobutton.disabled = false;
+highlightInput(); // in case the input is pre-filled
 
 const search = new URLSearchParams(window.location.search);
 for (const line of search.getAll('run')) await runCode(decodeURIComponent(line));


### PR DESCRIPTION
This allows multiline code to be entered into the REPL. A few other things:

- I've added a script which only builds the frontend, without changing the backend files. If you'd prefer I can gitignore this.
- I have Prettier set up, which has reformatted some of the JS/HTML slightly. I can revert this if you want (although you might want to set up a standard autoformatter for this eventually)